### PR TITLE
Refactor apply tool to use start/end position IDs

### DIFF
--- a/agents/manager.py
+++ b/agents/manager.py
@@ -88,12 +88,12 @@ read_document(asHTML: bool = False)
 ---
 
 `apply_tool_func(action_type: str,  chunk_id: Optional[str] = None)`
-*   **Description:** This tool applies a structural change to the document. It can insert, delete, or edit content at a specified location. Use it to make all document modifications. You must specify the action type, the target location (by selector or position_id), and, for inserts/edits, the chunk_id of the content to use. For inserts, also specify whether to insert BEFORE or AFTER the target.
+*   **Description:** This tool applies a structural change to the document. It can insert, delete, or edit content. Use it to make all document modifications. You must specify the action type, and for inserts/edits, the chunk_id of the content to use.
 *   **Purpose:** Executes a specific change on the document structure.
 *   **Parameters:**
     *   `action_type` (str): **REQUIRED.** Must be one of the following exact strings:
         *   `"INSERT"`: To add a new content chunk.
-        *   `"DELETE"`: To remove an existing element. No need to provide a chunk_id
+        *   `"DELETE"`: To remove an existing element. No need to provide a chunk_id.
         *   `"EDIT"`: To replace an existing element with a new content chunk.
 
 
@@ -145,13 +145,12 @@ read_document(asHTML: bool = False)
 
 
         Returns:
-            dict: {"status": "success", ...} with position_id and relative_position if valid, otherwise an error dict.
+            dict: {"status": "success", ...} with position_id_start and position_id_end if valid, otherwise an error dict.
         """
         result = self.apply_tool.apply(type, chunk_id, self.document_structure, self.last_prompt)
         # If error from apply_tool, propagate
         if "error" in result:
             return {"status": "error", "message": result["error"], "raw_response": result.get("raw_response")}
-        # Validate presence of position_id
 
         return {"status": "success", "message": result["message"]}
     
@@ -233,7 +232,7 @@ read_document(asHTML: bool = False)
             self.agent.invoke(Command(resume={"content": data.get('content','')}),{"configurable": {"thread_id": "2"}})
         elif data.get('tool_name','') == 'apply':
             logger.info(data)
-            self.agent.invoke(Command(resume={"status":"success"}),{"configurable": {"thread_id": "2"}}) # will default to success for testing
+            self.agent.invoke(Command(resume=data.get('content',{})),{"configurable": {"thread_id": "2"}})
 
 
     # Remove the old apply_tool method; use self.apply_tool.apply instead

--- a/agents/tools/apply.py
+++ b/agents/tools/apply.py
@@ -20,7 +20,7 @@ class ApplyTool:
     def apply(self, type: str, chunk_id: str,  document_structure: str, last_prompt: str):
         """
         Decide where to apply a chunk in the document structure using the LLM.
-        For type 'INSERT', returns position_id and relative_position ('AFTER' or 'BEFORE').
+        Returns the start and end position IDs for the apply action.
         """
         logger.info(f"--- Applying Chunk ---")
         logger.info(f"Type: {type}")
@@ -59,7 +59,9 @@ class ApplyTool:
 
         custom_response = {
             "status": result.get("status","error"),
-            "message": "Request applied to the document" if result.get("status","error") == "success" else "Couldn't apply the request to the document."
+            "message": "Request applied to the document" if result.get("status","error") == "success" else "Couldn't apply the request to the document.",
+            "data_position_id_start": result.get("data_position_id_start"),
+            "data_position_id_end": result.get("data_position_id_end")
         }
         if self.queue:
             self.queue.put_nowait(json.dumps({"type":"END","process":"APPLY", "chunk_id": chunk_id, "status": custom_response["status"]}))

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -10,14 +10,12 @@ This document describes the tools used by the agents in the document editing app
 -   **Use When:** The user asks to write, create, generate, summarize, or add any new text.
 -   **Output:** Returns a list of one or more generated content chunks, each with a unique `chunk_id`.
 
-### `apply_tool_func(action_type: str, target_location: str, chunk_id: Optional[str] = None, relative_position: Optional[str] = None)`
+### `apply_tool_func(action_type: str, chunk_id: Optional[str] = None)`
 
 -   **Purpose:** Applies a structural change to the document.
 -   **Parameters:**
     -   `action_type` (str): **REQUIRED.** Must be one of `"INSERT"`, `"DELETE"`, or `"EDIT"`.
-    -   `target_location` (str): **REQUIRED.** A precise CSS selector or description identifying the target HTML element.
     -   `chunk_id` (str): **REQUIRED for 'INSERT' and 'EDIT'**. The `chunk_id` of the content received from the `generate_content` tool.
-    -   `relative_position` (str): **REQUIRED *only* when `action_type` is "INSERT"**. Must be one of `"BEFORE"` or `"AFTER"`.
 
 ## ContentAgent Tools
 


### PR DESCRIPTION
- Removes the redundant `relevant_position` concept.
- Replaces `data-position-id` with `data-position-id-start` and `data-position-id-end` in the apply tool and sub-agent.
- Updates prompts, state management, and return values to reflect the new positioning logic.
- Aligns the interrupt/resume functionality of the `apply` tool with the `read_document` tool for better consistency.
- Updates tests and documentation to match the refactored implementation.